### PR TITLE
Remove unwanted deprecated warning

### DIFF
--- a/src/mb_sprintf.php
+++ b/src/mb_sprintf.php
@@ -45,7 +45,7 @@ final class mb_sprintf {
           $newformat .= mb_convert_encoding('%%', $encoding, 'UTF-8');
         }
         elseif ($type === 's') {
-          $arg = array_shift($argv);
+          $arg = (string) array_shift($argv);
           $arg = mb_convert_encoding($arg, 'UTF-8', $encoding);
           $padding_pre = '';
           $padding_post = '';


### PR DESCRIPTION
Hi,
if I do following code
```php
error_reporting(E_ALL);
echo mb_sprintf('%s', NULL);
```

I'll get following deprecated warning:
```
Deprecated: mb_convert_encoding(): Passing null to parameter #1 ($string) of type array|string is deprecated
```

It's the code `mb_convert_encoding($arg, 'UTF-8', $encoding);` that generates this warning, because `mb_convert_encoding()` doesn't want `$arg` to be null.
Calling `sprintf('%s', NULL)` doesn't generate a warning, so let's do the same with `mb_sprintf('%s', NULL)`.

The fix is pretty simple, and it also ensures that the argument passed to `mb_convert_encoding()` is always of type string.

